### PR TITLE
Fix external auth refresh for long queries.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -19,7 +19,7 @@ or Client Credential Auth.
 Other tools, environments, and authentication methods are not officially supported
 at this time. However, we welcome contributions that extend support to new
 frontiers. If you encounter issues outside these supported configurations and
-have an intention to contribute an improvement, we welcome your feature request. 
+have an intention to contribute an improvement, we welcome your feature request.
 
 If your use case falls outside the supported configurations and you cannot
 contribute an improvement at this time, we recommend evaluating commercial,

--- a/.github/workflows/pull-request-code-scan.yml
+++ b/.github/workflows/pull-request-code-scan.yml
@@ -9,6 +9,9 @@ on:
       - '**/*.yaml'
       - '**/CMakeLists.txt'
 
+permissions:
+  contents: read
+
 jobs:
   pr-code-scan:
     runs-on: ubuntu-latest
@@ -17,6 +20,11 @@ jobs:
       # Checkout the code
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Depth 0 gets all history for all branches. This
+          # enables the clang-format check to compare this PR
+          # against origin/main to see what's changed.
+          fetch-depth: 0
 
       # Run the trailing whitespace check
       - name: Check for trailing whitespace

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ find_package(nlohmann_json CONFIG REQUIRED)
 add_library(TrinoODBC SHARED
             "src/trinoAPIWrapper/authProvider/tokens/tokenCache.cpp"
             "src/trinoAPIWrapper/authProvider/tokens/tokenParser.cpp"
-            "src/trinoAPIWrapper/authProvider/clientCredAuthProvider.cpp" 
+            "src/trinoAPIWrapper/authProvider/clientCredAuthProvider.cpp"
             "src/trinoAPIWrapper/authProvider/externalAuthProvider.cpp"
             "src/trinoAPIWrapper/authProvider/noAuthProvider.cpp"
-            "src/trinoAPIWrapper/authProvider/tokenCacheAuthProviderBase.cpp" 
+            "src/trinoAPIWrapper/authProvider/tokenCacheAuthProviderBase.cpp"
             "src/trinoAPIWrapper/trinoQuery.cpp"
             "src/trinoAPIWrapper/connectionConfig.cpp"
             "src/trinoAPIWrapper/environmentConfig.cpp"

--- a/install/TrinoODBC_x64.wxs
+++ b/install/TrinoODBC_x64.wxs
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui" >
-  <Package Name="TrinoODBC 64-bit" 
-           Language="1033" 
-           Version="0.0.1" 
-           Manufacturer="Trino" 
+  <Package Name="TrinoODBC 64-bit"
+           Language="1033"
+           Version="0.0.1"
+           Manufacturer="Trino"
            UpgradeCode="2cc2e3fc-3a87-493d-99d0-643c3dd1df59"
-           InstallerVersion="500" 
-           Compressed="yes" 
+           InstallerVersion="500"
+           Compressed="yes"
            Scope="perMachine">
     <MajorUpgrade AllowSameVersionUpgrades="yes"
                   DowngradeErrorMessage="A newer version of the TrinoODBC 64-bit driver is already installed"/>

--- a/install/TrinoODBC_x86.wxs
+++ b/install/TrinoODBC_x86.wxs
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui" >
-  <Package Name="TrinoODBC 32-bit" 
-           Language="1033" 
-           Version="0.0.1" 
-           Manufacturer="Trino" 
+  <Package Name="TrinoODBC 32-bit"
+           Language="1033"
+           Version="0.0.1"
+           Manufacturer="Trino"
            UpgradeCode="d487a26c-ac90-487e-b332-e8ea34733229"
-           InstallerVersion="500" 
-           Compressed="yes" 
+           InstallerVersion="500"
+           Compressed="yes"
            Scope="perMachine">
     <MajorUpgrade AllowSameVersionUpgrades="yes"
                   DowngradeErrorMessage="A newer version of the TrinoODBC 32-bit driver is already installed"/>

--- a/src/trinoAPIWrapper/authProvider/tokens/tokenCache.cpp
+++ b/src/trinoAPIWrapper/authProvider/tokens/tokenCache.cpp
@@ -45,8 +45,17 @@ bool TokenCacheEntry::isExpired() {
   long long currentTimestamp = getSecondsSinceEpoch();
   // We need to get the "exp" key from the parsed access token, but only
   // if it exists. That's harder to do that one would hope.
-  long long expiresAt = this->parsedAccessToken.value<long long>("exp", 0LL);
-  return currentTimestamp > (expiresAt - EXPIRY_GRACE_PERIOD_S);
+  long long expiresAt    = this->parsedAccessToken.value<long long>("exp", 0LL);
+  long long timeToExpiry = expiresAt - currentTimestamp;
+  if (getLogLevel() <= LL_TRACE) {
+    WriteLog(LL_TRACE,
+             "  Current timestamp: " + std::to_string(currentTimestamp));
+    WriteLog(LL_TRACE,
+             "  Token expires timestamp: " + std::to_string(expiresAt));
+    WriteLog(LL_TRACE,
+             "  Token expires in " + std::to_string(timeToExpiry) + " seconds");
+  }
+  return (timeToExpiry - EXPIRY_GRACE_PERIOD_S) < 0;
 }
 
 

--- a/src/trinoAPIWrapper/connectionConfig.cpp
+++ b/src/trinoAPIWrapper/connectionConfig.cpp
@@ -106,7 +106,7 @@ std::string const ConnectionConfig::getStatementUrl() {
 
 CURL* ConnectionConfig::getCurl() {
   /*
-  Return a curl handle, reset it if neeeded, and it's ready to go.
+  Return a curl handle, reset it if needed, and it's ready to go.
   */
   if (this->curl == nullptr) {
     this->curl = curl_easy_init();


### PR DESCRIPTION
When running queries that do not exceed the expiration of the access token but are within the refresh grace period, make sure to remove the "Authorization" header from CURL before reauthenticating. It's still valid during the grace period, but we want to trigger a re-auth intentionally.

Fixes #1 