### PR TITLE
Enable compression for all libCurl use

### DIFF
--- a/src/trinoAPIWrapper/connectionConfig.cpp
+++ b/src/trinoAPIWrapper/connectionConfig.cpp
@@ -121,6 +121,8 @@ CURL* ConnectionConfig::getCurl() {
         this->curl, CURLOPT_HEADERDATA, &(this->responseHeaderData));
     // Set a timeout on all requests
     curl_easy_setopt(this->curl, CURLOPT_TIMEOUT_MS, 10000);
+    // Enable gzip and/or deflate on responses
+    curl_easy_setopt(this->curl, CURLOPT_ACCEPT_ENCODING, "gzip, deflate");
   }
 
 curlSetup:


### PR DESCRIPTION
Testing shows an approximate 25% improved query throughput with this enabled. 1 million rows per minute becomes 1.25 million rows per minute, give or take a few rows.

Fixes #3 