### PR TITLE
SQLColumns handle timestamp with time zone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ add_executable(TestDriver
     "test/connections/connectTest.cpp"
     "test/fixtures/sqlDriverConnectFixture.cpp"
     "test/functions/testCancel.cpp"
+    "test/functions/testColumns.cpp"
+    "test/functions/testDescribeCol.cpp"
     "test/functions/testGetConnectAttr.cpp"
     "test/functions/testGetInfo.cpp"
     "test/functions/testTables.cpp"

--- a/src/driver/driverConnect.cpp
+++ b/src/driver/driverConnect.cpp
@@ -63,7 +63,7 @@ SQLRETURN SQL_API SQLDriverConnect(SQLHDBC ConnectionHandle,
              "  An explicit DSN was not provided to SQLDriverConnect");
   }
 
-  WriteLog(LL_TRACE, "  Construting driver config");
+  WriteLog(LL_TRACE, "  Constructing driver config");
   DriverConfig config = driverConfigFromKVPs(kvps);
 
   // It's kind of unfortunate that we can't set the log level of the driver

--- a/src/driver/mappings/typeMappings.cpp
+++ b/src/driver/mappings/typeMappings.cpp
@@ -27,12 +27,12 @@ std::unordered_map<std::string, SQLLEN> TRINO_RAW_TYPE_TO_ODBC_SIZE_BYTES = {
     std::make_pair("real", 4),
     std::make_pair("boolean", 1),
     std::make_pair("varchar", SQL_NO_TOTAL),
-    std::make_pair("uuid", 16),
+    std::make_pair("uuid", sizeof(SQLGUID)),
     std::make_pair("decimal", SQL_NO_TOTAL),
-    std::make_pair("date", 6),
-    std::make_pair("time", 6),
-    std::make_pair("timestamp", 16),
-    std::make_pair("timestamp with time zone", 16),
+    std::make_pair("date", sizeof(SQL_DATE_STRUCT)),
+    std::make_pair("time", sizeof(SQL_TIME_STRUCT)),
+    std::make_pair("timestamp", sizeof(SQL_TIMESTAMP_STRUCT)),
+    std::make_pair("timestamp with time zone", sizeof(SQL_TIMESTAMP_STRUCT)),
 };
 
 /*

--- a/test/functions/testColumns.cpp
+++ b/test/functions/testColumns.cpp
@@ -1,0 +1,159 @@
+#include <windows.h>
+
+#include <gtest/gtest.h>
+#include <sql.h>
+#include <sqlext.h>
+
+#include "../constants.hpp"
+
+#include "../fixtures/sqlDriverConnectFixture.hpp"
+
+class ColumnsTest : public SQLDriverConnectFixture {};
+
+TEST_F(ColumnsTest, GetColumnsForBigint) {
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, this->hDbc, &hStmt);
+
+  ASSERT_EQ(ret, SQL_SUCCESS) << "Failed to allocate statement handle";
+
+  std::string catalog = "tpch";
+  std::string schema  = "sf1";
+  std::string table   = "customer";
+  std::string column  = "custkey";
+
+  ret = SQLColumns(hStmt,
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(catalog.c_str())),
+                   static_cast<SQLSMALLINT>(catalog.size()),
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(schema.c_str())),
+                   static_cast<SQLSMALLINT>(schema.size()),
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(table.c_str())),
+                   static_cast<SQLSMALLINT>(table.size()),
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(column.c_str())),
+                   static_cast<SQLSMALLINT>(column.size()));
+
+  ASSERT_EQ(ret, SQL_SUCCESS) << "Failed to execute SQLColumns";
+
+  // Run a fetch, since the results of this are returned as a result set.
+  // There should be only one row.
+  ret = SQLFetch(hStmt);
+  ASSERT_TRUE(ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO)
+      << "No row returned from SQLColumns";
+
+  SQLCHAR colName[256]     = {0};
+  SQLCHAR typeName[256]    = {0};
+  SQLSMALLINT dataType     = 0;
+  SQLINTEGER colSize       = 0;
+  SQLINTEGER decimalDigits = 0;
+
+  // Column 4: COLUMN_NAME
+  SQLGetData(hStmt, 4, SQL_C_CHAR, colName, sizeof(colName), NULL);
+  // Column 5: DATA_TYPE
+  SQLGetData(hStmt, 5, SQL_C_SSHORT, &dataType, 0, NULL);
+  // Column 6: TYPE_NAME
+  SQLGetData(hStmt, 6, SQL_C_CHAR, typeName, sizeof(typeName), NULL);
+  // Column 7: COLUMN_SIZE
+  SQLGetData(hStmt, 7, SQL_C_SLONG, &colSize, 0, NULL);
+  // Column 9: DECIMAL_DIGITS
+  SQLGetData(hStmt, 9, SQL_C_SLONG, &decimalDigits, 0, NULL);
+
+
+  // Assert column name and type
+  EXPECT_STREQ(reinterpret_cast<const char*>(colName), "custkey");
+  EXPECT_STREQ(reinterpret_cast<const char*>(typeName), "bigint");
+  EXPECT_EQ(dataType, SQL_BIGINT);
+  EXPECT_EQ(colSize, 19);
+  // Notably, this value differs from the value returned by
+  // system.jdbc.columns. JDBC reports integral numeric types
+  // as having NULL decimalDigits, but the ODBC spec says
+  // it should have zero decimal digits. This driver implements
+  // the ODBC behavior via some extra CASE statements. We test
+  // that it works here.
+  EXPECT_EQ(decimalDigits, 0);
+
+  // Should be only one row
+  ret = SQLFetch(hStmt);
+  EXPECT_EQ(ret, SQL_NO_DATA);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, hStmt);
+}
+
+
+TEST_F(ColumnsTest, GetColumnsForTimestampWithTimeZone) {
+  /*
+  Timestamp with time zone is unique because Trino's system.jdbc.columns
+  table returns values for this with a type code of 2014, which is
+  not standard SQL. It's probably a proprietary extension that's understood
+  only by their own JDBC driver.
+
+  This test verifies that it gets reported as a SQL_TYPE_TIMESTAMP instead,
+  which is the closest we can get with the vanilla ODBC 3.5 spec.
+
+  Notably, this is a TIMESTAMP(3) column, so it has "DECIMAL_DIGITS=3"
+  */
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, this->hDbc, &hStmt);
+
+  ASSERT_EQ(ret, SQL_SUCCESS) << "Failed to allocate statement handle";
+
+  std::string catalog = "system";
+  std::string schema  = "runtime";
+  std::string table   = "queries";
+  std::string column  = "created";
+
+  ret = SQLColumns(hStmt,
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(catalog.c_str())),
+                   static_cast<SQLSMALLINT>(catalog.size()),
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(schema.c_str())),
+                   static_cast<SQLSMALLINT>(schema.size()),
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(table.c_str())),
+                   static_cast<SQLSMALLINT>(table.size()),
+                   const_cast<unsigned char*>(
+                       reinterpret_cast<const unsigned char*>(column.c_str())),
+                   static_cast<SQLSMALLINT>(column.size()));
+
+  ASSERT_EQ(ret, SQL_SUCCESS) << "Failed to execute SQLColumns";
+
+  // Run a fetch, since the results of this are returned as a result set.
+  // There should be only one row.
+  ret = SQLFetch(hStmt);
+  ASSERT_TRUE(ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO)
+      << "No row returned from SQLColumns";
+
+  SQLCHAR colName[256]     = {0};
+  SQLCHAR typeName[256]    = {0};
+  SQLSMALLINT dataType     = 0;
+  SQLINTEGER colSize       = 0;
+  SQLINTEGER decimalDigits = 0;
+
+
+  // Column 4: COLUMN_NAME
+  SQLGetData(hStmt, 4, SQL_C_CHAR, colName, sizeof(colName), NULL);
+  // Column 5: DATA_TYPE
+  SQLGetData(hStmt, 5, SQL_C_SSHORT, &dataType, 0, NULL);
+  // Column 6: TYPE_NAME
+  SQLGetData(hStmt, 6, SQL_C_CHAR, typeName, sizeof(typeName), NULL);
+  // Column 7: COLUMN_SIZE
+  SQLGetData(hStmt, 7, SQL_C_SLONG, &colSize, 0, NULL);
+  // Column 9: DECIMAL_DIGITS
+  SQLGetData(hStmt, 9, SQL_C_SLONG, &decimalDigits, 0, NULL);
+
+
+  // Assert column name and type
+  EXPECT_STREQ(reinterpret_cast<const char*>(colName), "created");
+  EXPECT_STREQ(reinterpret_cast<const char*>(typeName), "timestamp");
+  EXPECT_EQ(dataType, SQL_TYPE_TIMESTAMP);
+  EXPECT_EQ(colSize, sizeof(SQL_TIMESTAMP_STRUCT));
+  // This column is a TIMESTAMP(3) WITH TIME ZONE, so we can test that "3".
+  EXPECT_EQ(decimalDigits, 3);
+
+  // Should be only one row
+  ret = SQLFetch(hStmt);
+  EXPECT_EQ(ret, SQL_NO_DATA);
+
+  SQLFreeHandle(SQL_HANDLE_STMT, hStmt);
+}

--- a/test/functions/testDescribeCol.cpp
+++ b/test/functions/testDescribeCol.cpp
@@ -1,0 +1,184 @@
+#include <windows.h>
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sql.h>
+#include <sqlext.h>
+
+#include "../constants.hpp"
+
+#include "../fixtures/sqlDriverConnectFixture.hpp"
+
+class SQLDescribColTest : public SQLDriverConnectFixture {};
+
+void setupTpchCustomerQuery(SQLHSTMT hStmt) {
+  std::string query = R"SQL(
+      SELECT *
+      FROM tpch.sf1.customer
+  )SQL";
+  SQLRETURN ret     = SQLExecDirect(hStmt, (SQLCHAR*)query.c_str(), SQL_NTS);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+}
+
+void setupTpchTinyintQuery(SQLHSTMT hStmt) {
+  /*
+  tpch doesn't contain any TINYINTs, so we can create one
+  manually on this very small nation table to enable testing
+  that type
+  */
+  std::string query = R"SQL(
+      SELECT
+        CAST(nationkey AS TINYINT) AS nationkey,
+        name,
+        regionkey,
+        comment
+      FROM tpch.sf1.nation
+  )SQL";
+  SQLRETURN ret     = SQLExecDirect(hStmt, (SQLCHAR*)query.c_str(), SQL_NTS);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+}
+
+TEST_F(SQLDescribColTest, TestDescribeBigintCol) {
+  // Allocate statement handle
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  // Run the query
+  setupTpchCustomerQuery(hStmt);
+
+  // Prepare buffers for SQLDescribeCol
+  SQLCHAR colName[128];
+  SQLSMALLINT nameLen       = 0;
+  SQLSMALLINT dataType      = 0;
+  SQLULEN colSize           = 0;
+  SQLSMALLINT decimalDigits = 0;
+  SQLSMALLINT nullable      = 0;
+
+  // Describe the first column (custkey)
+  ret = SQLDescribeCol(hStmt,
+                       1, // Column number (1-based)
+                       colName,
+                       sizeof(colName),
+                       &nameLen,
+                       &dataType,
+                       &colSize,
+                       &decimalDigits,
+                       &nullable);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  EXPECT_STREQ((const char*)colName, "custkey");
+  EXPECT_EQ(dataType, SQL_BIGINT);
+
+  // Free statement handle
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+}
+
+TEST_F(SQLDescribColTest, TestDescribeVarcharCol) {
+  // Allocate statement handle
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  // Run the query
+  setupTpchCustomerQuery(hStmt);
+
+  // Prepare buffers for SQLDescribeCol
+  SQLCHAR colName[128];
+  SQLSMALLINT nameLen       = 0;
+  SQLSMALLINT dataType      = 0;
+  SQLULEN colSize           = 0;
+  SQLSMALLINT decimalDigits = 0;
+  SQLSMALLINT nullable      = 0;
+
+  // Describe the second column (name)
+  ret = SQLDescribeCol(hStmt,
+                       2, // Column number (1-based)
+                       colName,
+                       sizeof(colName),
+                       &nameLen,
+                       &dataType,
+                       &colSize,
+                       &decimalDigits,
+                       &nullable);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  EXPECT_STREQ((const char*)colName, "name");
+  EXPECT_EQ(dataType, SQL_VARCHAR);
+
+  // Free statement handle
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+}
+
+
+TEST_F(SQLDescribColTest, TestDescribeDoubleColumn) {
+  // Allocate statement handle
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  // Run the query
+  setupTpchCustomerQuery(hStmt);
+
+  // Prepare buffers for SQLDescribeCol
+  SQLCHAR colName[128];
+  SQLSMALLINT nameLen       = 0;
+  SQLSMALLINT dataType      = 0;
+  SQLULEN colSize           = 0;
+  SQLSMALLINT decimalDigits = 0;
+  SQLSMALLINT nullable      = 0;
+
+  // Describe the sixth column (acctbal)
+  ret = SQLDescribeCol(hStmt,
+                       6, // Column number (1-based)
+                       colName,
+                       sizeof(colName),
+                       &nameLen,
+                       &dataType,
+                       &colSize,
+                       &decimalDigits,
+                       &nullable);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  EXPECT_STREQ((const char*)colName, "acctbal");
+  EXPECT_EQ(dataType, SQL_DOUBLE);
+
+  // Free statement handle
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+}
+
+TEST_F(SQLDescribColTest, TestDescribeTinyintColumn) {
+  // Allocate statement handle
+  SQLRETURN ret = SQLAllocHandle(SQL_HANDLE_STMT, hDbc, &hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  // Run the query
+  setupTpchTinyintQuery(hStmt);
+
+  // Prepare buffers for SQLDescribeCol
+  SQLCHAR colName[128];
+  SQLSMALLINT nameLen       = 0;
+  SQLSMALLINT dataType      = 0;
+  SQLULEN colSize           = 0;
+  SQLSMALLINT decimalDigits = 0;
+  SQLSMALLINT nullable      = 0;
+
+  // Describe the first column (nationkey)
+  ret = SQLDescribeCol(hStmt,
+                       1, // Column number (1-based)
+                       colName,
+                       sizeof(colName),
+                       &nameLen,
+                       &dataType,
+                       &colSize,
+                       &decimalDigits,
+                       &nullable);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+
+  EXPECT_STREQ((const char*)colName, "nationkey");
+  EXPECT_EQ(dataType, SQL_TINYINT);
+
+  // Free statement handle
+  ret = SQLFreeHandle(SQL_HANDLE_STMT, hStmt);
+  ASSERT_EQ(ret, SQL_SUCCESS);
+}


### PR DESCRIPTION
Handle type code 2014 in SQLColumns - it appears
to be a proprietary extension to trino that works
with trino's JDBC driver. In the world of ODBC,
the closest we can come is to a regular timestamp
which is type code 93.

Fixes #14 